### PR TITLE
Tweak an indent for add_index

### DIFF
--- a/lib/generators/crono_trigger/migration/templates/create_table_migration.rb
+++ b/lib/generators/crono_trigger/migration/templates/create_table_migration.rb
@@ -28,7 +28,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= Rails::VERSION::M
       t.timestamps<%= Rails::VERSION::MAJOR >=5 ? " null: false" : "" %>
 <% end -%>
     end
-    <% attributes.select { |attribute| attribute.respond_to?(:token?) && attribute.token? }.each do |attribute| -%>
+<% attributes.select { |attribute| attribute.respond_to?(:token?) && attribute.token? }.each do |attribute| -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>, unique: true
 <% end -%>
 <% attributes_with_index.each do |attribute| -%>


### PR DESCRIPTION
# Summary
This is a cosmetic change.
I found broken an indent for `add_index`.

# Behavour 
This is a migration file after generated by `rails g crono_trigger:model RSSRegister`.

## Expected behavour
```ruby
      t.timestamps null: false
    end

    add_index :rss_registers, [:next_execute_at, :execute_lock, :started_at, :finished_at], name: "crono_trigger_index_on_rss_registers"
```

## Actual behavour
```ruby
      t.timestamps null: false
    end

        add_index :rss_registers, [:next_execute_at, :execute_lock, :started_at, :finished_at], name: "crono_trigger_index_on_rss_registers"
```