### PR TITLE
Fix typo in CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ $ crono_trigger MailNotification
 $ crono_trigger --help
 Usage: crono_trigger [options] MODEL [MODEL..]
     -f, --config-file=CONFIG         Config file (ex. ./crono_trigger.rb)
-    -e, --envornment=ENV             Set environment name (ex. development, production)
+    -e, --environment=ENV            Set environment name (ex. development, production)
     -p, --polling-thread=SIZE        Polling thread size (Default: 1)
     -i, --polling-interval=SECOND    Polling interval seconds (Default: 5)
     -c, --concurrency=SIZE           Execute thread size (Default: 25)

--- a/lib/crono_trigger/cli.rb
+++ b/lib/crono_trigger/cli.rb
@@ -14,7 +14,7 @@ opt_parser = OptionParser.new do |opts|
     options[:config] = cfg
   end
 
-  opts.on("-e", "--envornment=ENV", "Set environment name (ex. development, production)") do |env|
+  opts.on("-e", "--environment=ENV", "Set environment name (ex. development, production)") do |env|
     options[:env] = env
   end
 


### PR DESCRIPTION
Just found a simple typo in the CLI option so corrected it.