### PR TITLE
Fix: checked out connection is not used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ gemfile:
   - gemfiles/activerecord-42.gemfile
   - gemfiles/activerecord-50.gemfile
   - gemfiles/activerecord-51.gemfile
+before_install:
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
+env:
+  - DB=sqlite
+  - DB=mysql MYSQL_RESTART_COMMAND="sudo service mysql restart"

--- a/crono_trigger.gemspec
+++ b/crono_trigger.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 4.2"
 
   spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "mysql2"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "rollbar"
   spec.add_development_dependency "bundler", "~> 1.14"

--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -34,12 +34,9 @@ module CronoTrigger
       records = []
       primary_key_offset = nil
       begin
-        begin
-          conn = model.connection_pool.checkout
+        model.connection_pool.with_connection do
           records = model.executables_with_lock(primary_key_offset: primary_key_offset)
           primary_key_offset = records.last && records.last.id
-        ensure
-          model.connection_pool.checkin(conn)
         end
 
         records.each do |record|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,18 @@ require "timecop"
 
 Time.zone = "UTC"
 
-ActiveRecord::Base.establish_connection(
-  adapter: "sqlite3",
-  database: ":memory:"
-)
+case ENV["DB"]
+when "mysql"
+  ActiveRecord::Base.establish_connection(
+    adapter: "mysql2",
+    database: "test"
+  )
+else
+  ActiveRecord::Base.establish_connection(
+    adapter: "sqlite3",
+    database: ":memory:"
+  )
+end
 
 class Notification < ActiveRecord::Base
   include CronoTrigger::Schedulable
@@ -62,6 +70,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
+    ActiveRecord::Base.connection.verify!
     Notification.delete_all
     Notification.results.clear
   end


### PR DESCRIPTION
ConnectionPool#checkout doesn't affect
model.connection unlike ConnectionPool#connection,
so the checked out connection is not used
in model.executables_with_lock.
If MySQL is restarted, "MySQL client is not connected"
errors occurs due to this.