### PR TITLE
Load "oj" in CronoTrigger::Web explicitly

### DIFF
--- a/lib/crono_trigger/web.rb
+++ b/lib/crono_trigger/web.rb
@@ -1,6 +1,7 @@
 require "crono_trigger"
 require "sinatra/base"
 require "rack/contrib/post_body_content_type_parser"
+require "oj"
 
 module CronoTrigger
   class Web < Sinatra::Application


### PR DESCRIPTION
This PR will fix errors which occur in a Rails application without "oj" like below:

```
Started GET "/crono_trigger/workers.json" for 127.0.0.1 at 2019-03-16 02:19:06 +0900
2019-03-16 02:19:06 - NameError - uninitialized constant CronoTrigger::Web::Oj:
        /Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.1/lib/bootsnap/load_path_cache/core_ext/active_support.rb:76:in `block in load_missing_constant'
        /Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.1/lib/bootsnap/load_path_cache/core_ext/active_support.rb:8:in `without_bootsnap_cache'
        /Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.1/lib/bootsnap/load_path_cache/core_ext/active_support.rb:76:in `rescue in load_missing_constant'
        /Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.1/lib/bootsnap/load_path_cache/core_ext/active_support.rb:58:in `load_missing_constant'
        /Users/arabiki/ghq/src/github.com/joker1007/crono_trigger/lib/crono_trigger/web.rb:22:in `block in <class:Web>'
        /Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/sinatra-2.0.5/lib/sinatra/base.rb:1635:in `call'
        /Users/arabiki/.anyenv/envs/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/sinatra-2.0.5/lib/sinatra/base.rb:1635:in `block in compile!'
-- snip --
```
