### PR TITLE
Make started_at nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class CreateMailNotifications < ActiveRecord::Migration
       t.datetime  :next_execute_at
       t.datetime  :last_executed_at
       t.integer   :execute_lock, limit: 8, default: 0, null: false
-      t.datetime  :started_at, null: false
+      t.datetime  :started_at
       t.datetime  :finished_at
       t.string    :last_error_name
       t.string    :last_error_reason
@@ -118,7 +118,7 @@ class MailNotification < ActiveRecord::Base
 end
 
 # one time schedule
-MailNotification.create(next_execute_at: Time.current.since(5.minutes))
+MailNotification.create.activate_schedule!(at: Time.current.since(5.minutes))
 
 # cron schedule
 MailNotification.create(cron: "0 12 * * *").activate_schedule!

--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -155,6 +155,8 @@ module CronoTrigger
         merge_updated_at_for_crono_trigger!(attributes)
         update_columns(attributes)
       end
+
+      self
     end
 
     def retry!

--- a/lib/generators/crono_trigger/migration/templates/create_table_migration.rb
+++ b/lib/generators/crono_trigger/migration/templates/create_table_migration.rb
@@ -18,7 +18,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= Rails::VERSION::M
       t.string    :timezone
       t.integer   :execute_lock, limit: 8, default: 0, null: false
       t.string    :locked_by
-      t.datetime  :started_at, null: false
+      t.datetime  :started_at
       t.datetime  :finished_at
       t.string    :last_error_name
       t.string    :last_error_reason


### PR DESCRIPTION
We receive `ActiveRecord::NotNullViolation` when we execute the example code in README, so `started_at` should be nullable or `started_at` should be specified in the example.