### PR TITLE
Add `#execute_now`

### DIFF
--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -217,11 +217,11 @@ module CronoTrigger
       update_columns(attributes)
     end
 
-    def crono_trigger_lock!
+    def crono_trigger_lock!(**attributes)
       attributes = {
         crono_trigger_column_name(:execute_lock) => Time.current.to_i,
         crono_trigger_column_name(:locked_by) => CronoTrigger.config.worker_id
-      }
+      }.merge(attributes)
       merge_updated_at_for_crono_trigger!(attributes)
       update_columns(attributes)
     end
@@ -265,6 +265,11 @@ module CronoTrigger
 
     def crono_trigger_column_name(name)
       self.class.crono_trigger_column_name(name)
+    end
+
+    def execute_now
+      crono_trigger_lock!(next_execute_at: Time.now)
+      do_execute
     end
 
     private


### PR DESCRIPTION
Hello,

I write a patch to add `Schedulable#execute_now` method to execute CronoTrigger schedulable models on Rails process directly.

# Motivation

## Situation

I have the code that is time-based or executed immediately using CronoTrigger.
For performance, I wanted a bypass that would use the Rails process directly and prevent the CronoTrigger worker from running immediately.

## Problem

When I create some schedulable models without `next_execution_at`, they can't retry with CronoTrigger Admin Web.
But when I have create the models with `next_execution_at`, CronoTrigger Worker will execute them.
So I must set `next_execution_at` and lock the models at the same time.

But the locking logic in CronoTrigger `#crono_trigger_lock!` updates only `execute_lock` and `locked_by`.
We can't set `next_execution_at` in the atomic logic.

# Solution
I enhanced the method `#crono_trigger_lock!` to accept optional updating attributes.
And I added `#execute_now` method to lock the schedulable model and update `next_execution_at` at the same time.

When I call `#execute_now`, the receiver schedulable model:
* locks not to execute by CronoTrigger workers.
* sets `next_execution_at` to retry and display on CronoTrigger Admin Web.
* calls `#do_execute`
   * to call `#execute` method and various callbacks if registered.