### PR TITLE
`#execute_now` for unpersisted model

### DIFF
--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -273,6 +273,7 @@ module CronoTrigger
 
     def execute_now
       crono_trigger_lock!(next_execute_at: Time.now)
+      save! if new_record?
       do_execute
     end
 

--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -223,7 +223,11 @@ module CronoTrigger
         crono_trigger_column_name(:locked_by) => CronoTrigger.config.worker_id
       }.merge(attributes)
       merge_updated_at_for_crono_trigger!(attributes)
-      update_columns(attributes)
+      if new_record?
+        self.attributes = attributes
+      else
+        update_columns(attributes)
+      end
     end
 
     def crono_trigger_unlock!

--- a/spec/crono_trigger/schedulable_spec.rb
+++ b/spec/crono_trigger/schedulable_spec.rb
@@ -51,6 +51,11 @@ RSpec.describe CronoTrigger::Schedulable do
       started_at: Time.current.since(2.day),
     ).tap(&:activate_schedule!)
   end
+  let(:new_notification) do
+    Notification.new(
+      started_at: Time.current,
+    )
+  end
 
   describe "before_create callback" do
     it "calculate_next_execute_at" do
@@ -517,6 +522,14 @@ RSpec.describe CronoTrigger::Schedulable do
       next_execute_at = Time.utc(2017, 6, 18, 1, 0, 30)
       notification1.crono_trigger_lock!(next_execute_at: next_execute_at)
       expect(notification1.next_execute_at).to eq(next_execute_at)
+    end
+
+    it "lock even if unpersisted" do
+      expect(new_notification.locking?).to be_falsey
+      expect(new_notification.new_record?).to be_truthy
+      new_notification.crono_trigger_lock!
+      expect(new_notification.locking?).to be_truthy
+      expect(new_notification.new_record?).to be_truthy
     end
   end
 


### PR DESCRIPTION
Thank you to review and merge https://github.com/joker1007/crono_trigger/pull/22.
It improves my application performance, but I realize that there is still room for improvement.
So I wrote the patch again.

I need to persist a schedulable model before calling `#execute_now` with the current implementation, but it causes RDB requests `INSERT` -> `UPDATE`.
`UPDATE` may be slow because it needs finding, checking lock, etc.
So I would like to call `#execute_now` for an unpersisted model to reduce `UPDATE`.