### PR TITLE
Add GlobalExceptionHandler and refine error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ class MailNotification < ActiveRecord::Base
     send_mail
 
     throw :retry # break execution and retry task
-    throw :abort # break execution and raise AbortExecution. AbortExecution is not retried
+    throw :abort # break execution
     throw :ok    # break execution and handle task as success
     throw :ok_without_reset    # break execution and handle task as success but without schedule reseting and unlocking
   end

--- a/lib/crono_trigger.rb
+++ b/lib/crono_trigger.rb
@@ -19,6 +19,7 @@ module CronoTrigger
     executor_thread: 25,
     model_names: nil,
     error_handlers: [],
+    global_error_handlers: [],
   )
 
   def self.config

--- a/lib/crono_trigger/global_exception_handler.rb
+++ b/lib/crono_trigger/global_exception_handler.rb
@@ -1,0 +1,29 @@
+module CronoTrigger
+  class GlobalExceptionHandler
+    def self.handle_global_exception(ex)
+      new.handle_global_exception(ex)
+    end
+
+    def handle_global_exception(ex)
+      handlers = CronoTrigger.config.global_error_handlers
+      handlers.each do |callable|
+        callable, arity = ensure_callable(callable)
+
+        args = [ex]
+        args = arity < 0 ? args : args.take(arity)
+        callable.call(*args)
+      end
+    rescue Exception => e
+      ActiveRecord::Base.logger.error("CronoTrigger error handler raises error")
+      ActiveRecord::Base.logger.error(e)
+    end
+
+    private
+
+    def ensure_callable(callable)
+      if callable.respond_to?(:call)
+        return callable, callable.arity
+      end
+    end
+  end
+end

--- a/lib/crono_trigger/models/execution.rb
+++ b/lib/crono_trigger/models/execution.rb
@@ -11,6 +11,8 @@ module CronoTrigger
         executing: "executing", 
         completed: "completed",
         failed: "failed",
+        retrying: "retrying",
+        aborted: "aborted",
       }
 
       def self.create_with_timestamp!

--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -84,6 +84,9 @@ module CronoTrigger
         @logger.info "(executor-thread-#{Thread.current.object_id}) Execute #{record.class}-#{record.id}"
         record.do_execute
       end
+    rescue Exception => ex
+      @logger.error(ex)
+      CronoTrigger::GlobalExceptionHandler.handle_global_exception(ex)
     end
 
     def unlock_overflowed_records(model, overflowed_record_ids)

--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -22,8 +22,9 @@ module CronoTrigger
               poll(model)
             rescue ThreadError => e
               @logger.error(e) unless e.message == "queue empty"
-            rescue => e
-              @logger.error(e)
+            rescue => ex
+              @logger.error(ex)
+              CronoTrigger::GlobalExceptionHandler.handle_global_exception(ex)
             ensure
               @model_queue << model_name if model_name
             end
@@ -63,14 +64,7 @@ module CronoTrigger
             @executor.post do
               @execution_counter.increment
               begin
-                model.connection_pool.with_connection do
-                  @logger.info "(executor-thread-#{Thread.current.object_id}) Execute #{record.class}-#{record.id}"
-                  begin
-                    record.do_execute
-                  rescue Exception => e
-                    @logger.error(e)
-                  end
-                end
+                process_record(record)
               ensure
                 @execution_counter.decrement
               end
@@ -83,7 +77,16 @@ module CronoTrigger
       end while overflowed_record_ids.empty? && records.any?
     end
 
-    private def unlock_overflowed_records(model, overflowed_record_ids)
+    private 
+
+    def process_record(record)
+      record.class.connection_pool.with_connection do
+        @logger.info "(executor-thread-#{Thread.current.object_id}) Execute #{record.class}-#{record.id}"
+        record.do_execute
+      end
+    end
+
+    def unlock_overflowed_records(model, overflowed_record_ids)
       model.connection_pool.with_connection do
         unless overflowed_record_ids.empty?
           model.where(id: overflowed_record_ids).crono_trigger_unlock_all!

--- a/lib/crono_trigger/rollbar.rb
+++ b/lib/crono_trigger/rollbar.rb
@@ -2,11 +2,14 @@ require 'rollbar'
 
 module Rollbar
   class CronoTrigger
-    def self.handle_exception(ex, record)
+    def self.handle_exception(ex, record = nil)
       scope = {
         framework: "CronoTrigger: #{::CronoTrigger::VERSION}",
-        context: "#{record.class}/#{record.id}"
       }
+
+      if record
+        scope.merge!({context: "#{record.class}/#{record.id}"})
+      end
 
       Rollbar.scope(scope).error(ex, use_exception_level_filters: true)
     end
@@ -20,6 +23,11 @@ Rollbar.plugins.define('crono_trigger') do
     CronoTrigger.config.error_handlers << proc do |ex, record|
       Rollbar.reset_notifier!
       Rollbar::CronoTrigger.handle_exception(ex, record)
+    end
+
+    CronoTrigger.config.global_error_handlers << proc do |ex|
+      Rollbar.reset_notifier!
+      Rollbar::CronoTrigger.handle_exception(ex)
     end
   end
 end

--- a/lib/crono_trigger/rollbar.rb
+++ b/lib/crono_trigger/rollbar.rb
@@ -21,12 +21,10 @@ Rollbar.plugins.define('crono_trigger') do
 
   execute! do
     CronoTrigger.config.error_handlers << proc do |ex, record|
-      Rollbar.reset_notifier!
       Rollbar::CronoTrigger.handle_exception(ex, record)
     end
 
     CronoTrigger.config.global_error_handlers << proc do |ex|
-      Rollbar.reset_notifier!
       Rollbar::CronoTrigger.handle_exception(ex)
     end
   end

--- a/spec/crono_trigger/worker_spec.rb
+++ b/spec/crono_trigger/worker_spec.rb
@@ -62,5 +62,20 @@ RSpec.describe CronoTrigger::Worker do
       sleep 2
       expect(worker.polling_threads[0]).to be_quiet
     end
+
+    describe "error handling" do
+      context "failed to register worker" do
+        before do
+          expect(CronoTrigger::Models::Worker).to receive(:find_or_initialize_by)
+            .with(worker_id: CronoTrigger.config.worker_id)
+            .and_raise(ActiveRecord::StatementInvalid)
+        end
+
+        it "call global_error_handlers" do
+          assert_calling_global_error_handlers
+          worker.send(:heartbeat)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What
- Add GlobalExceptionHandler
- Change error handling for retry and abort

Breaking Changes
- manually retry and abort are not recorded at last_error_info