### PR TITLE
Change calculate_next_execute_at to return a value that considers the value of finished_at.

### DIFF
--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -294,7 +294,7 @@ module CronoTrigger
         calculated = Chrono::NextTime.new(now: cron_now, source: self[crono_trigger_column_name(:cron)]).to_time
 
         return calculated unless self[crono_trigger_column_name(:finished_at)]
-        return nil if calculated > self[crono_trigger_column_name(:finished_at)]
+        return if calculated > self[crono_trigger_column_name(:finished_at)]
 
         calculated
       end

--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -257,7 +257,7 @@ module CronoTrigger
     end
 
     def locking?(at: Time.now)
-      self[crono_trigger_column_name(:execute_lock)] > 0 && 
+      self[crono_trigger_column_name(:execute_lock)] > 0 &&
         self[crono_trigger_column_name(:execute_lock)] >= at.to_f - self.class.execute_lock_timeout
     end
 
@@ -291,7 +291,12 @@ module CronoTrigger
         tz = self[crono_trigger_column_name(:timezone)].try { |zn| TZInfo::Timezone.get(zn) }
         base = [now, self[crono_trigger_column_name(:started_at)]].compact.max
         cron_now = tz ? base.in_time_zone(tz) : base
-        Chrono::NextTime.new(now: cron_now, source: self[crono_trigger_column_name(:cron)]).to_time
+        calculated = Chrono::NextTime.new(now: cron_now, source: self[crono_trigger_column_name(:cron)]).to_time
+
+        return calculated unless self[crono_trigger_column_name(:finished_at)]
+        return nil if calculated > self[crono_trigger_column_name(:finished_at)]
+
+        calculated
       end
     end
 

--- a/spec/crono_trigger/schedulable_spec.rb
+++ b/spec/crono_trigger/schedulable_spec.rb
@@ -217,9 +217,11 @@ RSpec.describe CronoTrigger::Schedulable do
     it "consider finished_at" do
       Timecop.freeze(Time.utc(2017, 6, 18, 17, 0)) do
         aggregate_failures do
-          expect(notification7.send(:calculate_next_execute_at)).to eq(Time.use_zone(notification7.timezone) { Time.zone.local(2017, 6, 20, 18, 10) })
-          notification7.update_column(:finished_at, Time.current)
-          expect(notification7.send(:calculate_next_execute_at)).to be nil
+          next_execute_at = notification5.send(:calculate_next_execute_at)
+          notification5.finished_at = next_execute_at
+          expect(next_execute_at).to eq(Time.utc(2017, 6, 18, 18, 10))
+          notification5.finished_at = next_execute_at - 1
+          expect(notification5.send(:calculate_next_execute_at)).to be nil
         end
       end
     end

--- a/spec/crono_trigger/schedulable_spec.rb
+++ b/spec/crono_trigger/schedulable_spec.rb
@@ -213,6 +213,16 @@ RSpec.describe CronoTrigger::Schedulable do
         end
       end
     end
+
+    it "consider finished_at" do
+      Timecop.freeze(Time.utc(2017, 6, 18, 17, 0)) do
+        aggregate_failures do
+          expect(notification7.send(:calculate_next_execute_at)).to eq(Time.use_zone(notification7.timezone) { Time.zone.local(2017, 6, 20, 18, 10) })
+          notification7.update_column(:finished_at, Time.current)
+          expect(notification7.send(:calculate_next_execute_at)).to be nil
+        end
+      end
+    end
   end
 
   describe "#do_execute" do


### PR DESCRIPTION
## problem
If the value of `next_execute_at` is in and `finished_at` has passed, the query will gradually become overloaded as it continues to ride the crono_trigger search.

## solution
Change `calculate_next_execute_at` return `nil` if the result is after `finished_at`.