### PR TITLE
Fix worker_id option

### DIFF
--- a/lib/crono_trigger/cli.rb
+++ b/lib/crono_trigger/cli.rb
@@ -67,7 +67,7 @@ end
 
 CronoTrigger.load_config(options[:config], options[:env]) if options[:config]
 
-%i(polling_thread polling_interval execute_thread).each do |name|
+%i(worker_id polling_thread polling_interval execute_thread).each do |name|
   CronoTrigger.config[name] = options[name] if options[name]
 end
 


### PR DESCRIPTION
The `worker_id` is not being passed as an option to the command, so this has been fixed.