### PR TITLE
Make PollThread work efficiently

### DIFF
--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -50,7 +50,7 @@ module CronoTrigger
     end
 
     def poll(model)
-      @logger.debug "(polling-thread-#{Thread.current.object_id}) Poll #{model}"
+      @logger.info "(polling-thread-#{Thread.current.object_id}) Poll #{model}"
       records = []
       overflowed_record_ids = []
 

--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -77,7 +77,7 @@ module CronoTrigger
       end while overflowed_record_ids.empty? && records.any?
     end
 
-    private 
+    private
 
     def process_record(record)
       record.class.connection_pool.with_connection do

--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -34,7 +34,7 @@ module CronoTrigger
 
       define_model_callbacks :execute, :retry
 
-      scope :executables, ->(from: Time.current, limit: CronoTrigger.config.executor_thread * 3 || 100, including_locked: false) do
+      scope :executables, ->(from: Time.current, limit: CronoTrigger.config.executor_thread * 3, including_locked: false) do
         t = arel_table
 
         rel = where(t[crono_trigger_column_name(:next_execute_at)].lteq(from))
@@ -63,7 +63,7 @@ module CronoTrigger
     end
 
     module ClassMethods
-      def executables_with_lock(limit: CronoTrigger.config.executor_thread * 3 || 100)
+      def executables_with_lock(limit: CronoTrigger.config.executor_thread * 3)
         ids = executables(limit: limit).pluck(:id)
         records = []
         ids.each do |id|

--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -65,6 +65,7 @@ module CronoTrigger
     module ClassMethods
       def executables_with_lock(limit: CronoTrigger.config.executor_thread * 3)
         ids = executables(limit: limit).pluck(:id)
+        maybe_has_next = !ids.empty?
         records = []
         ids.each do |id|
           transaction do
@@ -75,7 +76,7 @@ module CronoTrigger
             end
           end
         end
-        records
+        [records, maybe_has_next]
       end
 
       def crono_trigger_column_name(name)

--- a/lib/crono_trigger/worker.rb
+++ b/lib/crono_trigger/worker.rb
@@ -24,6 +24,7 @@ module CronoTrigger
         min_threads: 1,
         max_threads: CronoTrigger.config.executor_thread,
         max_queue: CronoTrigger.config.executor_thread * 2,
+        fallback_policy: :caller_runs,
       )
       @execution_counter = Concurrent::AtomicFixnum.new
       @logger = Logger.new(STDOUT) unless @logger

--- a/spec/crono_trigger/schedulable_spec.rb
+++ b/spec/crono_trigger/schedulable_spec.rb
@@ -139,35 +139,40 @@ RSpec.describe CronoTrigger::Schedulable do
       end
 
       Timecop.freeze(Time.utc(2017, 6, 18, 1, 15)) do
-        records = Notification.executables_with_lock(limit: 1)
+        records, maybe_has_next = Notification.executables_with_lock(limit: 1)
         aggregate_failures do
           expect(records).to match_array([notification2])
           expect(records[0].reload.execute_lock).to eq(Time.current.to_i)
+          expect(maybe_has_next).to be true
         end
 
-        records = Notification.executables_with_lock(limit: 1)
+        records, maybe_has_next = Notification.executables_with_lock(limit: 1)
         aggregate_failures do
           expect(records).to match_array([notification3])
           expect(records[0].reload.execute_lock).to eq(Time.current.to_i)
+          expect(maybe_has_next).to be true
         end
 
-        records = Notification.executables_with_lock(limit: 1)
+        records, maybe_has_next = Notification.executables_with_lock(limit: 1)
         aggregate_failures do
           expect(records).to be_empty
+          expect(maybe_has_next).to be false
         end
       end
 
       Timecop.freeze(Time.utc(2017, 6, 18, 1, 25, 1)) do
-        records = Notification.executables_with_lock(limit: 1)
+        records, maybe_has_next = Notification.executables_with_lock(limit: 1)
         aggregate_failures do
           expect(records).to match_array([notification2])
           expect(records[0].reload.execute_lock).to eq(Time.current.to_i)
+          expect(maybe_has_next).to be true
         end
 
-        records = Notification.executables_with_lock(limit: 1)
+        records, maybe_has_next = Notification.executables_with_lock(limit: 1)
         aggregate_failures do
           expect(records).to match_array([notification3])
           expect(records[0].reload.execute_lock).to eq(Time.current.to_i)
+          expect(maybe_has_next).to be true
         end
       end
     end

--- a/spec/integration/execution_spec.rb
+++ b/spec/integration/execution_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+RSpec.describe "Execute records" do
+  let(:worker_class) do
+    Class.new do
+      include CronoTrigger::Worker
+
+      def initialize
+        @logger = Logger.new(nil)
+        super
+      end
+    end
+  end
+
+  context "when there are so many records that the execution queue reaches the maximum size" do
+    around do |example|
+      original_polling_interval = CronoTrigger.config.polling_interval
+      CronoTrigger.config.polling_interval = 2
+
+      example.run
+
+      CronoTrigger.config.polling_interval = original_polling_interval
+    end
+
+    before do
+      allow_any_instance_of(Notification).to receive(:execute) do
+        sleep 1
+      end
+
+      now = Time.now
+      # executor.max_length + executor.max_queue + 1
+      76.times do |i|
+        Notification.create!(name: i.to_s, started_at: now, next_execute_at: now)
+      end
+    end
+
+    it "processes all the records without returning from #poll" do
+      worker = worker_class.new
+      Thread.start { worker.run }
+      sleep CronoTrigger.config.polling_interval + 2
+
+      expect(Notification.executables).not_to be_exists
+    ensure
+      worker.stop
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,14 +19,16 @@ case ENV["DB"]
 when "mysql"
   ActiveRecord::Base.establish_connection(
     adapter: "mysql2",
-    database: "test"
+    database: "test",
+    pool: CronoTrigger.config.executor_thread + 5,
   )
 else
   db_path = File.join(__dir__, "testdb.sqlite3")
   File.unlink(db_path) if File.exist?(db_path)
   ActiveRecord::Base.establish_connection(
     adapter: "sqlite3",
-    database: File.join(__dir__, "testdb.sqlite3")
+    database: File.join(__dir__, "testdb.sqlite3"),
+    pool: CronoTrigger.config.executor_thread + 5,
   )
 
   RSpec.configure do |config|


### PR DESCRIPTION
This PR includes two main changes to make `PollThread` work efficiently: The first is in the commit https://github.com/joker1007/crono_trigger/commit/6804884016f44cca5c3e7c4cafb93d251c2a4776, and the second is in the commit https://github.com/joker1007/crono_trigger/commit/269cc8d342c2c8606cd6070ed662cec5c85d949f.
Both changes prevent `PollThread` from returning from `#poll` when there are still executable records and can avoid meaningless sleep.
For more details, please see the commit messages.