### PR TITLE
Return from #poll if stop flag is set to true

### DIFF
--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -56,7 +56,7 @@ module CronoTrigger
       @logger.info "(polling-thread-#{Thread.current.object_id}) Poll #{model}"
 
       maybe_has_next = true
-      while maybe_has_next
+      while maybe_has_next && !@stop_flag.set?
         records, maybe_has_next = model.connection_pool.with_connection do
           model.executables_with_lock
         end


### PR DESCRIPTION
This PR fixes a regression of https://github.com/joker1007/crono_trigger/pull/32, and makes PollThread return from `#poll` when the worker receives SIGTERM. Otherwise, `#poll` never ends until there are no more records.
