### PR TITLE
Use Concurrent::ImmediateExecutor if concurrency is 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,17 @@ And other options is following.
 
 ```
 $ crono_trigger --help
-Usage: crono_trigger [options] MODEL [MODEL..]
+Usage: crono_trigger [options] [MODEL..]
+  If MODEL is not given, Search classes including CronoTrigger::Schedulable module automatically.
+    -w, --worker-id=ID               Worker ID (default: First local ip address which is not loopback
     -f, --config-file=CONFIG         Config file (ex. ./crono_trigger.rb)
     -e, --environment=ENV            Set environment name (ex. development, production)
-    -p, --polling-thread=SIZE        Polling thread size (Default: 1)
+    -p, --polling-thread=SIZE        Polling thread size (Default: Min of (target model count or processor_count)
     -i, --polling-interval=SECOND    Polling interval seconds (Default: 5)
     -c, --concurrency=SIZE           Execute thread size (Default: 25)
+                                     Note that, when the execution queue is full, polling threads also process
+                                     records unless this value is 1, so the actual concurrency can be greater
+                                     than this value.
     -l, --log=LOGFILE                Set log output destination (Default: STDOUT or ./crono_trigger.log if daemonize is true)
         --log-level=LEVEL            Set log level (Default: info)
     -d, --daemonize                  Daemon mode

--- a/lib/crono_trigger/cli.rb
+++ b/lib/crono_trigger/cli.rb
@@ -30,7 +30,10 @@ opt_parser = OptionParser.new do |opts|
     options[:polling_interval] = i
   end
 
-  opts.on("-c", "--concurrency=SIZE", Integer, "Execute thread size (Default: 25)") do |i|
+  opts.on("-c", "--concurrency=SIZE", Integer, "Execute thread size (Default: 25)",
+    "Note that, when the execution queue is full, polling threads also process",
+    "records unless this value is 1, so the actual concurrency can be greater",
+    "than this value.") do |i|
     options[:executor_thread] = i
   end
 

--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -5,7 +5,7 @@ module CronoTrigger
       @stop_flag = stop_flag
       @logger = logger
       @executor = executor
-      if @executor.fallback_policy != :caller_runs
+      if @executor.fallback_policy != :caller_runs && !@executor.is_a?(Concurrent::ImmediateExecutor)
         raise ArgumentError, "executor's fallback policies except for :caller_runs are not supported"
       end
       @execution_counter = execution_counter

--- a/spec/crono_trigger/polling_thread_spec.rb
+++ b/spec/crono_trigger/polling_thread_spec.rb
@@ -30,19 +30,10 @@ RSpec.describe CronoTrigger::PollingThread do
     ).tap(&:activate_schedule!)
   end
 
-  let(:immediate_executor_class_with_fallabck_policy) do
-    Class.new(Concurrent::ImmediateExecutor) do
-      def initialize(*args, **kwargs)
-        super
-        @fallback_policy = :caller_runs
-      end
-    end
-  end
-
   describe "#run" do
     let(:stop_flag) { ServerEngine::BlockingFlag.new }
     let(:model_queue) { Queue.new.tap { |q| q << "Notification" } }
-    let(:executor) { immediate_executor_class_with_fallabck_policy.new }
+    let(:executor) { Concurrent::ImmediateExecutor.new }
     subject(:polling_thread) { CronoTrigger::PollingThread.new(model_queue, stop_flag, Logger.new($stdout), executor, Concurrent::AtomicFixnum.new) }
 
     before do
@@ -72,7 +63,7 @@ RSpec.describe CronoTrigger::PollingThread do
   describe "#poll" do
     subject(:polling_thread) { CronoTrigger::PollingThread.new(Queue.new, ServerEngine::BlockingFlag.new, Logger.new($stdout), executor, Concurrent::AtomicFixnum.new) }
 
-    let(:executor) { immediate_executor_class_with_fallabck_policy.new }
+    let(:executor) { Concurrent::ImmediateExecutor.new }
 
     it "execute model#execute method" do
       Timecop.freeze(Time.utc(2017, 6, 18, 1, 0)) do

--- a/spec/integration/execution_spec.rb
+++ b/spec/integration/execution_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe "Execute records" do
     Class.new do
       include CronoTrigger::Worker
 
-      def initialize
-        @logger = Logger.new(nil)
-        super
+      def initialize(logger)
+        @logger = logger
+        super()
       end
     end
   end
+  let(:logger) { Logger.new(log_buffer) }
+  let(:log_buffer) { StringIO.new }
 
   context "when there are so many records that the execution queue reaches the maximum size" do
     around do |example|
@@ -35,7 +37,7 @@ RSpec.describe "Execute records" do
     end
 
     it "processes all the records without returning from #poll" do
-      worker = worker_class.new
+      worker = worker_class.new(logger)
       Thread.start { worker.run }
       sleep CronoTrigger.config.polling_interval + 2
 
@@ -66,7 +68,7 @@ RSpec.describe "Execute records" do
         true
       end
 
-      worker = worker_class.new
+      worker = worker_class.new(logger)
       Thread.start { worker.run }
       sleep CronoTrigger.config.polling_interval + 1
 
@@ -86,12 +88,43 @@ RSpec.describe "Execute records" do
       # Make maybe_has_next true
       allow_any_instance_of(Notification).to receive(:locking?) { true }
 
-      worker = worker_class.new
+      worker = worker_class.new(logger)
       Thread.start do
         sleep CronoTrigger.config.polling_interval + 1
         worker.stop
       end
       Timeout.timeout(CronoTrigger.config.polling_interval + 2) { worker.run }
+    end
+  end
+
+  context "when the concurrency is 1" do
+    around do |example|
+      original_executor_thread = CronoTrigger.config.executor_thread
+      CronoTrigger.config.executor_thread = 1
+
+      example.run
+
+      CronoTrigger.config.executor_thread = original_executor_thread
+    end
+
+    before do
+      now = Time.now
+      Notification.create!(name: 'notification', started_at: now, next_execute_at: now)
+    end
+
+    it "processes records using the polling thread" do
+      worker = worker_class.new(logger)
+      Thread.start { worker.run }
+      sleep CronoTrigger.config.polling_interval + 1
+
+      expect(Notification.executables).not_to be_exists
+
+      polling_thread_id = log_buffer.string.slice(/polling-thread-(\d+)/, 1)
+      expect(polling_thread_id).not_to be_nil
+      executor_thread_id = log_buffer.string.slice(/executor-thread-(\d+)/, 1)
+      expect(executor_thread_id).to eq(polling_thread_id)
+    ensure
+      worker.stop
     end
   end
 end


### PR DESCRIPTION
Because the reason why executor_thread is set to 1 might be that the application is not thread-safe. The caller thread of `ThreadPoolExecutor` with fallback policy `:caller_runs` can also process tasks, that is, tasks can be processed by multiple threads.