### PR TITLE
Fix worker metrics current_executing_size and current_queue_size

### DIFF
--- a/lib/crono_trigger/worker.rb
+++ b/lib/crono_trigger/worker.rb
@@ -97,8 +97,8 @@ module CronoTrigger
         begin
           worker_record = CronoTrigger::Models::Worker.find_or_initialize_by(worker_id: @crono_trigger_worker_id)
           worker_record.max_thread_size = @executor.max_length
-          worker_record.current_executing_size = @executor.scheduled_task_count
-          worker_record.current_queue_size = @execution_counter.value
+          worker_record.current_executing_size = @execution_counter.value
+          worker_record.current_queue_size = @executor.queue_length
           worker_record.executor_status = executor_status
           worker_record.polling_model_names = @model_names
           worker_record.last_heartbeated_at = Time.current


### PR DESCRIPTION
I think `current_executing_size` means the number of threads that are processing a record, and if so, `@execution_counter.value` is what you expect. `@executor.scheduled_task_count` is the total number of scheduled tasks since `@executor` is created.
In a similar way, `current_queue_size` should correspond `@executor.queue_length`.