### PR TITLE
Add `--fetch-records` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Usage: crono_trigger [options] MODEL [MODEL..]
     -p, --polling-thread=SIZE        Polling thread size (Default: 1)
     -i, --polling-interval=SECOND    Polling interval seconds (Default: 5)
     -c, --concurrency=SIZE           Execute thread size (Default: 25)
-    -r, --fetch-records=SIZE         Fetch record count by polling thread (Default: concurrency * 3)
+    -r, --fetch-records=SIZE         Record count fetched by polling thread (Default: concurrency * 3)
     -l, --log=LOGFILE                Set log output destination (Default: STDOUT or ./crono_trigger.log if daemonize is true)
         --log-level=LEVEL            Set log level (Default: info)
     -d, --daemonize                  Daemon mode

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Usage: crono_trigger [options] MODEL [MODEL..]
     -p, --polling-thread=SIZE        Polling thread size (Default: 1)
     -i, --polling-interval=SECOND    Polling interval seconds (Default: 5)
     -c, --concurrency=SIZE           Execute thread size (Default: 25)
+    -r, --fetch-records=SIZE         Fetch record count by polling thread (Default: concurrency * 3)
     -l, --log=LOGFILE                Set log output destination (Default: STDOUT or ./crono_trigger.log if daemonize is true)
         --log-level=LEVEL            Set log level (Default: info)
     -d, --daemonize                  Daemon mode

--- a/lib/crono_trigger.rb
+++ b/lib/crono_trigger.rb
@@ -17,6 +17,7 @@ module CronoTrigger
     polling_thread: nil,
     polling_interval: 5,
     executor_thread: 25,
+    fetch_records: nil, # default is executor_thread * 3
     model_names: nil,
     error_handlers: [],
     global_error_handlers: [],

--- a/lib/crono_trigger/cli.rb
+++ b/lib/crono_trigger/cli.rb
@@ -34,7 +34,7 @@ opt_parser = OptionParser.new do |opts|
     options[:executor_thread] = i
   end
 
-  opts.on("-r", "--fetch-records=SIZE", Integer, "Fetch record count by polling thread (Default: concurrency * 3)") do |i|
+  opts.on("-r", "--fetch-records=SIZE", Integer, "Record count fetched by polling thread (Default: concurrency * 3)") do |i|
     options[:fetch_records] = i
   end
 

--- a/lib/crono_trigger/cli.rb
+++ b/lib/crono_trigger/cli.rb
@@ -34,6 +34,10 @@ opt_parser = OptionParser.new do |opts|
     options[:executor_thread] = i
   end
 
+  opts.on("-r", "--fetch-records=SIZE", Integer, "Fetch record count by polling thread (Default: concurrency * 3)") do |i|
+    options[:fetch_records] = i
+  end
+
   opts.on("-l", "--log=LOGFILE", "Set log output destination (Default: STDOUT or ./crono_trigger.log if daemonize is true)") do |log|
     options[:log] = log
   end
@@ -67,7 +71,7 @@ end
 
 CronoTrigger.load_config(options[:config], options[:env]) if options[:config]
 
-%i(worker_id polling_thread polling_interval executor_thread).each do |name|
+%i(worker_id polling_thread polling_interval executor_thread fetch_records).each do |name|
   CronoTrigger.config[name] = options[name] if options[name]
 end
 

--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -58,7 +58,7 @@ module CronoTrigger
       maybe_has_next = true
       while maybe_has_next && !@stop_flag.set?
         records, maybe_has_next = model.connection_pool.with_connection do
-          model.executables_with_lock
+          model.executables_with_lock(limit: CronoTrigger.config.fetch_records || CronoTrigger.config.executor_thread * 3)
         end
 
         records.each do |record|

--- a/lib/crono_trigger/version.rb
+++ b/lib/crono_trigger/version.rb
@@ -1,3 +1,3 @@
 module CronoTrigger
-  VERSION = "0.6.5"
+  VERSION = "0.6.6"
 end


### PR DESCRIPTION
Add `--fetch-records` option to control querying count in once polling loop
