### PR TITLE
Fix event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ If `crono_trigger/rollbar` is required, Add Rollbar logging process to `CronoTri
 
 This gem provides the following events for [Active Support Instrumentation](https://guides.rubyonrails.org/active_support_instrumentation.html).
 
-### CronoTrigger::Events::MONITOR
+### monitor.crono\_trigger
 
 This event is triggered every 20 seconds by the first active worker in worker_id order, so note that other workers don't receive the event.
 
@@ -224,7 +224,7 @@ This event is triggered every 20 seconds by the first active worker in worker_id
 | max\_latency\_sec        | The maximum amount of time since executable records got ready to be processed |
 
 
-### CronoTrigger::Events::PROCESS_RECORD
+### process\_record.crono\_trigger
 
 This event is triggered every time a record finishes being processed.
 

--- a/lib/crono_trigger/events.rb
+++ b/lib/crono_trigger/events.rb
@@ -1,6 +1,6 @@
 module CronoTrigger
   module Events
-    MONITOR = -"crono_trigger.monitor"
-    PROCESS_RECORD = -"crono_trigger.process_record"
+    MONITOR = -"monitor.crono_trigger"
+    PROCESS_RECORD = -"process_record.crono_trigger"
   end
 end


### PR DESCRIPTION
The pattern of event name is "#{event}.#{namespace}".
cf. https://github.com/rails/rails/blob/v7.0.3/activesupport/lib/active_support/subscriber.rb#L113-L115

For example, the following code doesn't work correctly without these changes:

```ruby
class CronoTriggerEventSubscriber < ActiveSupport::Subscriber
  attach_to :crono_trigger

  def monitor(event)
    %i[executable_count max_lock_duration_sec max_latency_sec].each do |name|
      puts "#{name}:#{event.payload[name]} (#{event.payload[:model_name]}"
    end
  end
end
```