### PR TITLE
Add include CronoTrigger::Schedulable to the generator template

### DIFF
--- a/lib/generators/crono_trigger/model/templates/model.rb
+++ b/lib/generators/crono_trigger/model/templates/model.rb
@@ -1,5 +1,7 @@
 <% module_namespacing do -%>
 class <%= class_name %> < <%= parent_class_name.classify %>
+  include CronoTrigger::Schedulable
+
 <% attributes.select(&:reference?).each do |attribute| -%>
   belongs_to :<%= attribute.name %><%= ', polymorphic: true' if attribute.polymorphic? %><%= ', required: true' if attribute.required? %>
 <% end -%>


### PR DESCRIPTION
Currently, models generated by `rails g crono_trigger:model` don't include the `CronoTrigger::Schedulable` module although it's required to enable CronoTrigger.
So, I'd have it included in this commit.