### PR TITLE
Fix to include started_at in job execution time

### DIFF
--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -295,7 +295,7 @@ module CronoTrigger
     def calculate_next_execute_at(now = Time.current)
       if self[crono_trigger_column_name(:cron)]
         tz = self[crono_trigger_column_name(:timezone)].try { |zn| TZInfo::Timezone.get(zn) }
-        base = [now, self[crono_trigger_column_name(:started_at)]].compact.max
+        base = [now, self[crono_trigger_column_name(:started_at)]&.-(1.minute)].compact.max
         cron_now = tz ? base.in_time_zone(tz) : base
         calculated = Chrono::NextTime.new(now: cron_now, source: self[crono_trigger_column_name(:cron)]).to_time
 

--- a/spec/crono_trigger/schedulable_spec.rb
+++ b/spec/crono_trigger/schedulable_spec.rb
@@ -51,6 +51,22 @@ RSpec.describe CronoTrigger::Schedulable do
       started_at: Time.current.since(2.day),
     ).tap(&:activate_schedule!)
   end
+  let(:notification8) do
+    started_at = 1.day.since.beginning_of_day
+    Notification.create!(
+      name: "notification8",
+      cron: "#{started_at.min} #{started_at.hour} #{started_at.day} * *",
+      started_at: started_at,
+    ).tap(&:activate_schedule!)
+  end
+  let(:notification9) do
+    started_at = Time.current.beginning_of_day
+    Notification.create!(
+      name: "notification9",
+      cron: "#{started_at.min} #{started_at.hour} #{started_at.day} * *",
+      started_at: started_at,
+    ).tap(&:activate_schedule!)
+  end
   let(:new_notification) do
     Notification.new(
       started_at: Time.current,
@@ -231,6 +247,20 @@ RSpec.describe CronoTrigger::Schedulable do
           expect(next_execute_at).to eq(Time.utc(2017, 6, 18, 18, 10))
           notification5.finished_at = next_execute_at - 1
           expect(notification5.send(:calculate_next_execute_at)).to be nil
+        end
+      end
+    end
+
+    context "when started_at and first execution time are the same" do
+      context "when started_at is future" do
+        it "executes at started_at" do
+          expect(notification8.next_execute_at).to eq(notification8.started_at)
+        end
+      end
+
+      context "when started_at is present or past" do
+        it "executes at the same datetime as started_at next month" do
+          expect(notification9.next_execute_at).to eq(1.month.since(notification9.started_at))
         end
       end
     end


### PR DESCRIPTION
When started_at is a future date and started_at is the same as the first execution time, jobs will not be executed.
This is because the next execution time is calculated based on started_at. 

```rb
# Example
# 1. if the current date is before 2023/5/30
# 2. Jobs start at 2023/5/30 00:00 and execute at 00:00 on the 30th of every month (cron: `0 0 30 * *`)

started_at = Time.new(2023, 5, 30)
Chrono::NextTime.new(now: started_at, source: "0 0 30 * *").to_time
#=> 2023-06-30 00:00:00 +0900
# not execute at 2023-05-30 00:00:00 +0900
```

This PR fixes to execute jobs even at started_at.