### PR TITLE
Fix "NoMethodError: undefined method `each' for nil:NilClass"

### DIFF
--- a/lib/crono_trigger/worker.rb
+++ b/lib/crono_trigger/worker.rb
@@ -38,13 +38,14 @@ module CronoTrigger
       @heartbeat_thread = run_heartbeat_thread
       @signal_fetcn_thread = run_signal_fetch_thread
       @monitor_thread = run_monitor_thread
-      @worker_count_updater_thread = run_worker_count_updater_thread
 
       polling_thread_count = CronoTrigger.config.polling_thread || [@model_names.size, Concurrent.processor_count].min
       # Assign local variable for Signal handling
       polling_threads = polling_thread_count.times.map { PollingThread.new(@model_queue, @stop_flag, @logger, @executor, @execution_counter) }
       @polling_threads = polling_threads
       @polling_threads.each(&:run)
+
+      @worker_count_updater_thread = run_worker_count_updater_thread
 
       ServerEngine::SignalThread.new do |st|
         st.trap(:TSTP) do


### PR DESCRIPTION
This PR fixes the error that occurs at startup. It is caused by calling `@polling_threads.each` in update_worker_count because @polling_threads is assigned after run_worker_count_updater_thread is called.

Here is the stacktrace:

```
NoMethodError: undefined method `each' for nil:NilClass
block in update_worker_count(/app/vendor/bundle/ruby/3.0.0/gems/crono_trigger-0.8.0/lib/crono_trigger/worker.rb:209)
with_connection(/app/vendor/bundle/ruby/3.0.0/gems/activerecord-7.0.4.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:215)
update_worker_count(/app/vendor/bundle/ruby/3.0.0/gems/crono_trigger-0.8.0/lib/crono_trigger/worker.rb:206)
run_worker_count_updater_thread(/app/vendor/bundle/ruby/3.0.0/gems/crono_trigger-0.8.0/lib/crono_trigger/worker.rb:111)
run(/app/vendor/bundle/ruby/3.0.0/gems/crono_trigger-0.8.0/lib/crono_trigger/worker.rb:41)
main(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/worker.rb:81)
run(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/embedded_server.rb:26)
main(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/server.rb:128)
block in start_server(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/supervisor.rb:269)
block in fork(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/process_manager.rb:133)
block in fork(/app/vendor/bundle/ruby/3.0.0/gems/activesupport-7.0.4.3/lib/active_support/fork_tracker.rb:20)
fork(/app/vendor/bundle/ruby/3.0.0/gems/activesupport-7.0.4.3/lib/active_support/fork_tracker.rb:18)
fork(/app/vendor/bundle/ruby/3.0.0/gems/activesupport-7.0.4.3/lib/active_support/fork_tracker.rb:18)
fork(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/process_manager.rb:125)
start_server(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/supervisor.rb:260)
main(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/supervisor.rb:195)
main(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/daemon.rb:119)
run(/app/vendor/bundle/ruby/3.0.0/gems/serverengine-2.3.2/lib/serverengine/daemon.rb:68)
<top (required)>(/app/vendor/bundle/ruby/3.0.0/gems/crono_trigger-0.8.0/lib/crono_trigger/cli.rb:89)
require(/app/vendor/bundle/ruby/3.0.0/gems/crono_trigger-0.8.0/exe/crono_trigger:3)
<top (required)>(/app/vendor/bundle/ruby/3.0.0/gems/crono_trigger-0.8.0/exe/crono_trigger:3)
load(/app/bundle_bin/crono_trigger:27)
<main>(/app/bundle_bin/crono_trigger:27)
```
