### PR TITLE
Change the type of crono_trigger_workers.polling_model_names to text

### DIFF
--- a/lib/generators/crono_trigger/install/templates/install.rb
+++ b/lib/generators/crono_trigger/install/templates/install.rb
@@ -5,7 +5,7 @@ class CreateCronoTriggerSystemTables < ActiveRecord::Migration<%= Rails::VERSION
       t.integer  :current_executing_size, null: false
       t.integer  :current_queue_size, null: false
       t.string   :executor_status, null: false
-      t.string   :polling_model_names, null: false
+      t.text   :polling_model_names, null: false
       t.datetime :last_heartbeated_at, null: false
     end
 

--- a/spec/db/migrate/00_create_crono_trigger_system_tables.rb
+++ b/spec/db/migrate/00_create_crono_trigger_system_tables.rb
@@ -5,7 +5,7 @@ class CreateCronoTriggerSystemTables < ActiveRecord::VERSION::MAJOR >= 5 ? Activ
       t.integer  :current_executing_size, null: false
       t.integer  :current_queue_size, null: false
       t.string   :executor_status, null: false
-      t.string   :polling_model_names, null: false
+      t.text   :polling_model_names, null: false
       t.datetime :last_heartbeated_at, null: false
     end
 


### PR DESCRIPTION
Hi there,

I experienced an error that the length of `crono_trigger_workers.polling_model_names` reaches the upper limit in MySQL and change the column's type from varchar(255) to text to address the issue.
Therefore, I'd propose updating the column's type by default accordingly if there is no reason with the string type.

---
The polling_model_names column is a string, but it can be a longer
string than 255 characters, which is the upper limit of the string
length of `varchar(255)` in MySQL, and result in an error.
Therefore, it would be better to change the column type to text.

The column contains a comma-separated list of models, so the length of
the string can reach the limit when the number of models increases.
It should not impact performance since the column is not indexed.
