### PR TITLE
Introduce db_error_retriable_options

### DIFF
--- a/crono_trigger.gemspec
+++ b/crono_trigger.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack-contrib"
   spec.add_dependency "oj"
   spec.add_dependency "activerecord", ">= 4.2"
+  spec.add_dependency "retriable"
 
   spec.add_development_dependency "sqlite3", "~> 1.3"
   spec.add_development_dependency "mysql2"

--- a/lib/crono_trigger/polling_thread.rb
+++ b/lib/crono_trigger/polling_thread.rb
@@ -58,8 +58,10 @@ module CronoTrigger
 
       maybe_has_next = true
       while maybe_has_next && !@stop_flag.set?
-        records, maybe_has_next = model.connection_pool.with_connection do
-          model.executables_with_lock(limit: CronoTrigger.config.fetch_records || CronoTrigger.config.executor_thread * 3, worker_count: @worker_count)
+        records, maybe_has_next = CronoTrigger.retry_on_db_errors do
+          model.connection_pool.with_connection do
+            model.executables_with_lock(limit: CronoTrigger.config.fetch_records || CronoTrigger.config.executor_thread * 3, worker_count: @worker_count)
+          end
         end
 
         records.each do |record|

--- a/lib/crono_trigger/schedulable.rb
+++ b/lib/crono_trigger/schedulable.rb
@@ -81,6 +81,12 @@ module CronoTrigger
 
           return [records, maybe_has_next] if records.size == limit
         end
+
+        [records, maybe_has_next]
+      rescue => e
+        raise if records.empty?
+
+        logger&.warn("Failed to fetching some records but continue processing records: #{e} (#{e.class})")
         [records, maybe_has_next]
       end
 


### PR DESCRIPTION
This PR resolves https://github.com/joker1007/crono_trigger/issues/55 by allowing users to handle DB errors.

In our environment, I confirmed that the error had no longer happened using the following configurations:

```ruby
CronoTrigger.configure do |config|
  config[:db_error_retriable_options] = {
    tries: 7,
    on: {
      ActiveRecord::ConnectionNotEstablished => nil,
      Mysql2::Error::ConnectionError => nil,
      ActiveRecord::StatementInvalid => /MySQL server is running with the --read-only option/,
    },
    on_retry: proc do |exception, try, elapsed_time, interval|
      Rails.logger.info("#{try}th: Retry on #{exception.class}: #{exception}")
      next unless exception.is_a?(ActiveRecord::StatementInvalid)

      Rails.logger.info("#{try}th: Reconnect to MySQL on #{exception.class}: #{exception}")
      # NOTE: The connection acquired here might be different from the one used in the code that raised the error,
      #   but we don't have a way to get the latter connection.
      ActiveRecord::Base.connection_pool.with_connection(&:reconnect!)
    end,
  }
end
```