### PR TITLE
fix: deprecation warnings for `enum` definition since Rails 7.2

### DIFF
--- a/lib/crono_trigger/models/execution.rb
+++ b/lib/crono_trigger/models/execution.rb
@@ -7,13 +7,23 @@ module CronoTrigger
 
       scope :recently, ->(schedule_type:) { where(schedule_type: schedule_type).order(executed_at: :desc) }
 
-      enum status: {
-        executing: "executing", 
-        completed: "completed",
-        failed: "failed",
-        retrying: "retrying",
-        aborted: "aborted",
-      }
+      if ActiveRecord.version >= Gem::Version.new("7.0")
+        enum :status, {
+          executing: "executing",
+          completed: "completed",
+          failed: "failed",
+          retrying: "retrying",
+          aborted: "aborted",
+        }
+      else
+        enum status: {
+          executing: "executing",
+          completed: "completed",
+          failed: "failed",
+          retrying: "retrying",
+          aborted: "aborted",
+        }
+      end
 
       def self.create_with_timestamp!
         create!(executed_at: Time.current, status: :executing, worker_id: CronoTrigger.config.worker_id)

--- a/lib/crono_trigger/models/signal.rb
+++ b/lib/crono_trigger/models/signal.rb
@@ -5,7 +5,11 @@ module CronoTrigger
 
       IGNORE_THRESHOLD = 300
 
-      enum signal: {TERM: "TERM", USR1: "USR1", CONT: "CONT", TSTP: "TSTP"}
+      if ActiveRecord.version >= Gem::Version.new("7.0")
+        enum :signal, {TERM: "TERM", USR1: "USR1", CONT: "CONT", TSTP: "TSTP"}
+      else
+        enum signal: {TERM: "TERM", USR1: "USR1", CONT: "CONT", TSTP: "TSTP"}
+      end
 
       scope :sent_to_me, proc {
         raise "Must set worker_id" unless CronoTrigger.config.worker_id

--- a/lib/crono_trigger/models/worker.rb
+++ b/lib/crono_trigger/models/worker.rb
@@ -7,7 +7,11 @@ module CronoTrigger
 
       ALIVE_THRESHOLD = CronoTrigger::Worker::HEARTBEAT_INTERVAL * 5
 
-      enum executor_status: {running: "running", quiet: "quiet", shuttingdown: "shuttingdown", shutdown: "shutdown"}
+      if ActiveRecord.version >= Gem::Version.new("7.0")
+        enum :executor_status, {running: "running", quiet: "quiet", shuttingdown: "shuttingdown", shutdown: "shutdown"}
+      else
+        enum executor_status: {running: "running", quiet: "quiet", shuttingdown: "shuttingdown", shutdown: "shutdown"}
+      end
 
       if ActiveRecord.version >= Gem::Version.new("7.1.0")
         serialize :polling_model_names, coder: JSON


### PR DESCRIPTION
Since Rails 7.2, the `enum` definition with keyword arguments have been deprecated. See also the commit https://github.com/rails/rails/commit/1a92af2b51401a6013126a5573a95db34bbad7b2

Before this change, the following warnings are output during the test:

```sh-session
$ bundle exec rspec spec/crono_trigger/models/execution_spec.rb 2>&1 | grep -A1 'DEPRECATION'
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:
--
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:
--
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:
```

After this change, the warnings are gone.