### PR TITLE
Make Oj dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ require "crono_trigger/web"
 mount CronoTrigger::Web => '/crono_trigger'
 ```
 
+### JSON serialization
+
+The Admin Web renders JSON with the standard `json` gem by default.
+If [`oj`](https://github.com/ohler55/oj) is installed, it is used automatically instead.
+To opt in, add it to your Gemfile:
+
+```ruby
+gem 'oj'
+```
+
 ## Rollbar integration
 This gem has rollbar plugin.
 If `crono_trigger/rollbar` is required, Add Rollbar logging process to `CronoTrigger.config.error_handlers`

--- a/crono_trigger.gemspec
+++ b/crono_trigger.gemspec
@@ -28,12 +28,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tzinfo"
   spec.add_dependency "sinatra"
   spec.add_dependency "rack-contrib"
-  spec.add_dependency "oj"
+  spec.add_dependency "ostruct"
   spec.add_dependency "activerecord", ">= 4.2"
   spec.add_dependency "retriable"
 
   spec.add_development_dependency "sqlite3", ">= 1.3"
   spec.add_development_dependency "mysql2"
+  spec.add_development_dependency "oj" # optional at runtime
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "rollbar"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/crono_trigger/web.rb
+++ b/lib/crono_trigger/web.rb
@@ -1,7 +1,16 @@
 require "crono_trigger"
 require "sinatra/base"
 require "rack/contrib/post_body_content_type_parser"
-require "oj"
+
+# JSON serialization priority:
+# 1. Use Oj when it is installed (optional dependency).
+# 2. Otherwise fall back to ActiveSupport::JSON.encode, which uses the JSON gem internally.
+#    ActiveSupport::JSON (not ::JSON) keeps the compatibility with Oj.
+begin
+  require "oj"
+rescue LoadError
+  require "active_support/json/encoding"
+end
 
 module CronoTrigger
   class Web < Sinatra::Application
@@ -19,9 +28,9 @@ module CronoTrigger
       if params[:format] == "json"
         content_type :json
         @workers = CronoTrigger::Models::Worker.alive_workers
-        Oj.dump({
+        encode_json({
           records: @workers,
-        }, mode: :compat)
+        })
       else
         raise "unknown format"
       end
@@ -40,11 +49,11 @@ module CronoTrigger
           body ""
         else
           status 422
-          Oj.dump({error: "#{sig} signal is not supported"}, mode: :compat)
+          encode_json({error: "#{sig} signal is not supported"})
         end
       else
         status 422
-        Oj.dump({error: "Must set worker_id and signal"}, mode: :compat)
+        encode_json({error: "Must set worker_id and signal"})
       end
     end
 
@@ -52,9 +61,9 @@ module CronoTrigger
       if params[:format] == "json"
         content_type :json
         @signals = CronoTrigger::Models::Signal.order(sent_at: :desc).limit(30)
-        Oj.dump({
+        encode_json({
           records: @signals,
-        }, mode: :compat)
+        })
       else
         raise "unknown format"
       end
@@ -136,9 +145,9 @@ module CronoTrigger
               -"delay_sec" => r.locking?(at: now) ? 0 : (now - r[r.crono_trigger_column_name(:next_execute_at)]).to_i,
             }
           end
-          Oj.dump({
+          encode_json({
             records: records,
-          }, mode: :compat)
+          })
         else
           status 404
           "Model Class is not found"
@@ -156,9 +165,9 @@ module CronoTrigger
       if params[:format] == "json"
         content_type :json
         @models = CronoTrigger::Schedulable.included_by.map(&:name).sort
-        Oj.dump({
+        encode_json({
           models: @models,
-        }, mode: :compat)
+        })
       else
         raise "unknown format"
       end
@@ -189,9 +198,9 @@ module CronoTrigger
               -"error_reason" => r.error_reason,
             }
           end
-          Oj.dump({
+          encode_json({
             records: records,
-          }, mode: :compat)
+          })
         else
           status 404
           "Model Class is not found"
@@ -199,6 +208,12 @@ module CronoTrigger
       else
         raise "unknown format"
       end
+    end
+
+    private
+
+    def encode_json(obj)
+      defined?(Oj) ? Oj.dump(obj, mode: :compat) : ActiveSupport::JSON.encode(obj)
     end
   end
 end

--- a/spec/crono_trigger/web_spec.rb
+++ b/spec/crono_trigger/web_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require "crono_trigger/web"
+require "rack/mock"
+
+RSpec.describe CronoTrigger::Web do
+  shared_examples "JSON endpoints" do
+    let(:req) { Rack::MockRequest.new(described_class) }
+
+    let!(:signal) do
+      CronoTrigger::Models::Signal.create!(
+        worker_id: "w1",
+        signal: "TERM",
+        sent_at: Time.utc(2000, 1, 2, 3, 4, 5),
+      )
+    end
+
+    after { signal.delete }
+
+    it "GET /signals.json" do
+      res = req.get("/signals.json")
+
+      expect(res.status).to eq(200)
+      expect(res.content_type).to eq("application/json")
+      expect(JSON.parse(res.body)).to match(
+        "records" => [a_hash_including("sent_at" => "2000-01-02T03:04:05.000Z")],
+      )
+    end
+
+    it "GET /models.json" do
+      res = req.get("/models.json")
+
+      expect(res.status).to eq(200)
+      expect(res.content_type).to eq("application/json")
+      expect(JSON.parse(res.body)).to match("models" => [String])
+    end
+  end
+
+  context "when Oj is available" do
+    it "loads Oj" do
+      expect(defined?(Oj)).to eq("constant")
+    end
+
+    include_examples "JSON endpoints"
+  end
+
+  context "when Oj is not available" do
+    before { hide_const("Oj") }
+
+    include_examples "JSON endpoints"
+  end
+end


### PR DESCRIPTION
## Motivation

`CronoTrigger::Web` uses `Oj.dump` for JSON serialization, which forces `Oj` as a hard runtime dependency.

On the other hand, the standard `JSON` gem has also become quite fast recently. I'd like to use `JSON` instead of `Oj` sometimes to avoid third-party dependencies.

Ref: <https://github.com/ruby/json/blob/94c1af2/CHANGES.md>

## Overview

- Drop `oj` from runtime dependencies.
- Add `ostruct` as a runtime dependency (previously pulled in transitively by `oj`).
- Try requiring `oj`, otherwise fall back to `ActiveSupport::JSON.encode` (internally using `json`).
- Add specs for `CronoTrigger::Web`.

So if users want to still use `Oj`, they need to add it to their `Gemfile`, e.g.,

```diff
 gem 'crono_trigger'
+gem 'oj'
```